### PR TITLE
moved ueberauth config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,18 +40,6 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:user_id]
 
-config :ueberauth, Ueberauth,
-  providers: [
-    github: {Ueberauth.Strategy.Github, []}
-  ]
-
-config :ueberauth, Ueberauth.Strategy.Github.OAuth,
-  client_id: System.get_env("GITHUB_CLIENT_ID"),
-  client_secret: System.get_env("GITHUB_CLIENT_SECRET"),
-  site: "https://git.rockfin.com",
-  authorize_url: "https://git.rockfin.com/login/oauth/authorize",
-  token_url: "https://git.rockfin.com/login/oauth/access_token"
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -70,4 +70,16 @@ config :phoenix, :stacktrace_depth, 20
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
 
+config :ueberauth, Ueberauth,
+  providers: [
+    github: {Ueberauth.Strategy.Github, []}
+  ]
+
+config :ueberauth, Ueberauth.Strategy.Github.OAuth,
+  client_id: System.get_env("GITHUB_CLIENT_ID"),
+  client_secret: System.get_env("GITHUB_CLIENT_SECRET"),
+  site: "https://git.rockfin.com",
+  authorize_url: "https://git.rockfin.com/login/oauth/authorize",
+  token_url: "https://git.rockfin.com/login/oauth/access_token"
+
 import_config "dev.secret.exs"

--- a/lib/lucidboard/user_from_auth.ex
+++ b/lib/lucidboard/user_from_auth.ex
@@ -4,16 +4,12 @@ defmodule UserFromAuth do
   """
   require Logger
   require Poison
-
   alias Ueberauth.Auth
 
   def find_or_create(%Auth{provider: :identity} = auth) do
     case validate_pass(auth.credentials) do
-      :ok ->
-        {:ok, basic_info(auth)}
-
-      {:error, reason} ->
-        {:error, reason}
+      :ok -> {:ok, basic_info(auth)}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/lucidboard_web/controllers/auth_controller.ex
+++ b/lib/lucidboard_web/controllers/auth_controller.ex
@@ -2,7 +2,6 @@ defmodule LucidboardWeb.AuthController do
   @moduledoc """
   Auth controller responsible for handling Ueberauth responses
   """
-
   use LucidboardWeb, :controller
   plug(Ueberauth)
 

--- a/rel/config/config.toml
+++ b/rel/config/config.toml
@@ -7,3 +7,7 @@
 "Lucidboard.Repo".hostname = "${PG_HOST | default: db}"
 "Lucidboard.Repo".port = "${PG_PORT | default: 5432}"
 "Lucidboard.Repo".password = "${PG_PASS | default: verysecure123}"
+
+[ueberauth."Ueberauth.Strategy.Github.OAuth"]
+client_id = "${GITHUB_CLIENT_ID}"
+client_secret = "${GITHUB_CLIENT_SECRET}"


### PR DESCRIPTION
I'm just suggesting a couple changes. Let me know what you think.

I've moved the `:ueberauth` config to `dev.exs` because those environment variables should only be relevant in dev since those environment variables would be read at compile time. For the Distillery releases, I've added a few lines into `rel/config/config.toml` which are able to overlay runtime environment variables with our application environment config. (I wrote [TomlTransformer](https://github.com/djthread/toml_transformer) which can replace the env vars and other tricks.)

Thanks for fixing the remaining bits with the formatter :) 